### PR TITLE
Update Redirects Wizard domain from bootpack.dev to redirectswizard.com

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -379,8 +379,8 @@
 		},
 		{
 			name: 'Redirects Wizard',
-			url: 'https://redirects.bootpack.dev',
-			host: 'redirects.bootpack.dev',
+			url: 'https://redirectswizard.com',
+			host: 'redirectswizard.com',
 			imgSrc: redirectsWizard
 		},
 		{

--- a/src/routes/blog/screenshot-maker/+page.svelte
+++ b/src/routes/blog/screenshot-maker/+page.svelte
@@ -42,7 +42,7 @@
 					when you're making dependency updates to have an easy visual of the before-and-after. I
 					also add screenshots of projects to the <A
 						className="inline"
-						href="https://redirects.bootpack.dev/">Redirects Wizard</A
+						href="https://redirectswizard.com/">Redirects Wizard</A
 					> project when viewing the index of redirect batches. I also take screenshots of projects for
 					marketing and posting on websites. It's not the easiest thing to get a consistent screenshot
 					of a project, so I made a tool to do it.


### PR DESCRIPTION
## Summary

Updates all references to the Redirects Wizard project to use its new domain `redirectswizard.com` instead of the previous `redirects.bootpack.dev` domain.

## Changes

- Updated Redirects Wizard project URL and host in the homepage projects list (`src/routes/+page.svelte`)
- Updated Redirects Wizard link in the Screenshot Maker blog post (`src/routes/blog/screenshot-maker/+page.svelte`)

## Details

This change reflects a domain migration for the Redirects Wizard project. All user-facing links and references now point to the new `redirectswizard.com` domain.

https://claude.ai/code/session_01MGoen7RrQzDf6T7jb5Kvos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Redirects Wizard links to use the new `redirectswizard.com` address.
  - Updated the displayed website host in the site listing and related blog content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->