### PR TITLE
Add a "Suggest a restaurant" dialog to the restaurants page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ bun up                   # Update dependencies
 ### Framework & Deployment
 
 - **SvelteKit 2.x** with Svelte 5 (uses Svelte 5 runes syntax: `$props`, `$derived`, `$state`)
-- Deployed on **Vercel** using `@sveltejs/adapter-vercel`
+- Deployed on **Cloudflare Workers** using `@sveltejs/adapter-cloudflare`, configured in `wrangler.jsonc`
 - Uses **file-based routing** in `src/routes/`
 
 ### Key Architectural Patterns
@@ -91,6 +91,31 @@ Two image treatments, picked with `imageStyle`:
 Long titles are auto-shrunk to fit; the script warns if copy still overflows.
 `e2e/og-images.test.ts` asserts every route's `og:image`/`twitter:image` points at an
 existing 1200x630 JPEG.
+
+#### Restaurant Suggestions
+
+`/restaurants` has a "Suggest a restaurant" dialog, and it is the only page with a
+database behind it:
+
+1. `src/components/SuggestRestaurantDialog.svelte` is a native `<dialog>` opened
+   with `showModal()` (top layer, so it clears the sticky header and the map),
+   controlled by a `bind:open` prop. It owns its own submit state instead of the
+   page's `form` prop, so a suggestion never touches the page's filters or URL.
+2. The `suggest` action in `src/routes/restaurants/+page.server.ts` verifies
+   Turnstile, writes the row to **Cloudflare D1**, then sends the Telegram
+   notification. It stores first and notifies second: a saved-but-unannounced
+   suggestion is recoverable, an announced-but-lost one is not.
+3. The schema lives in `migrations/`, applied with
+   `bunx wrangler d1 migrations apply`. The `DB` binding is declared in
+   `wrangler.jsonc` and typed in `src/app.d.ts`.
+4. It reuses the contact form's `TURNSTILE_SECRET_KEY`, `TELEGRAM_BOT_TOKEN`, and
+   `TELEGRAM_CHAT_ID`. Without any of those, or without the binding, the action
+   fails with a visitor-facing "temporarily unavailable" message rather than
+   accepting a submission it would drop. `vite dev`/`vite preview` have no
+   binding; use `bunx wrangler dev` to exercise the whole path.
+
+`e2e/restaurant-suggestions.test.ts` intercepts the action, so the tests do not
+need Telegram, D1, or Turnstile configured.
 
 #### Image Handling
 
@@ -211,6 +236,9 @@ Required for production:
 
 - `PUBLIC_POSTHOG_API_KEY` - PostHog analytics key
 - `PUBLIC_POSTHOG_ENABLED` - Toggle analytics (set to "false" to disable)
+- `PUBLIC_TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` - Turnstile, used by the
+  contact form and the restaurant suggestion dialog
+- `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` - Where both of those forms notify
 
 See `.env.example` for reference.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,11 @@ database behind it:
    notification. It stores first and notifies second: a saved-but-unannounced
    suggestion is recoverable, an announced-but-lost one is not.
 3. The schema lives in `migrations/`, applied with
-   `bunx wrangler d1 migrations apply`. The `DB` binding is declared in
-   `wrangler.jsonc` and typed in `src/app.d.ts`.
+   `bunx wrangler d1 migrations apply`. The `DB` binding is typed in
+   `src/app.d.ts`, and its `wrangler.jsonc` block ships **commented out** with
+   an empty `database_id`: a Workers build fails outright on an id that is not a
+   real database, so the block is uncommented once the database exists (see the
+   README).
 4. It reuses the contact form's `TURNSTILE_SECRET_KEY`, `TELEGRAM_BOT_TOKEN`, and
    `TELEGRAM_CHAT_ID`. Without any of those, or without the binding, the action
    fails with a visitor-facing "temporarily unavailable" message rather than

--- a/README.md
+++ b/README.md
@@ -13,3 +13,34 @@ bun run dev -- --open
 A browser should open at [http://127.0.0.1:5173/](http://127.0.0.1:5173/) to see the result.
 
 You can start editing the page by modifying `src/routes/index.svelte`. The page auto-updates as you edit the file.
+
+## Restaurant suggestions
+
+The "Suggest a restaurant" dialog on `/restaurants` posts to the `suggest` form
+action in `src/routes/restaurants/+page.server.ts`, which stores the suggestion
+in Cloudflare D1 and then sends a Telegram notification. It reuses the contact
+form's `TURNSTILE_SECRET_KEY`, `TELEGRAM_BOT_TOKEN`, and `TELEGRAM_CHAT_ID`; the
+action refuses submissions rather than dropping them if any of those, or the D1
+binding, are missing.
+
+One-time setup:
+
+```bash
+# Create the database and paste the printed database_id into wrangler.jsonc
+bunx wrangler d1 create michaelbonner-dev
+
+# Apply the schema in migrations/
+bunx wrangler d1 migrations apply michaelbonner-dev --local   # local dev
+bunx wrangler d1 migrations apply michaelbonner-dev --remote  # production
+```
+
+To read what has come in:
+
+```bash
+bunx wrangler d1 execute michaelbonner-dev --remote \
+  --command "SELECT * FROM restaurant_suggestions ORDER BY created_at DESC LIMIT 20"
+```
+
+The binding only exists inside the Workers runtime, so `bun run dev` and
+`bun run preview` will report suggestions as unavailable. Use
+`bunx wrangler dev` to exercise the whole path locally.

--- a/README.md
+++ b/README.md
@@ -23,16 +23,22 @@ form's `TURNSTILE_SECRET_KEY`, `TELEGRAM_BOT_TOKEN`, and `TELEGRAM_CHAT_ID`; the
 action refuses submissions rather than dropping them if any of those, or the D1
 binding, are missing.
 
-One-time setup:
+One-time setup. The `d1_databases` block in `wrangler.jsonc` ships commented
+out, because a Workers build fails outright on a `database_id` that is not a real
+database:
 
 ```bash
-# Create the database and paste the printed database_id into wrangler.jsonc
+# Create the database, then paste the printed id into the commented-out
+# d1_databases block in wrangler.jsonc and uncomment it
 bunx wrangler d1 create michaelbonner-dev
 
 # Apply the schema in migrations/
 bunx wrangler d1 migrations apply michaelbonner-dev --local   # local dev
 bunx wrangler d1 migrations apply michaelbonner-dev --remote  # production
 ```
+
+Until that is done the dialog reports suggestions as unavailable rather than
+accepting submissions it cannot store.
 
 To read what has come in:
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,7 @@
 {
 	"words": [
 		"acceleratedep",
+		"AUTOINCREMENT",
 		"bikepacking",
 		"blackthornsoftware",
 		"Bonner",
@@ -60,6 +61,7 @@
 		"Shure",
 		"soooooo",
 		"subreddits",
+		"Sugarhouse",
 		"sveltejs",
 		"sveltekit",
 		"Tesseract",

--- a/e2e/restaurant-suggestions.test.ts
+++ b/e2e/restaurant-suggestions.test.ts
@@ -1,0 +1,174 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+/** The form action `use:enhance` posts to. */
+const isSuggestAction = (url: URL) => url.pathname === '/restaurants' && url.search === '?/suggest';
+
+/**
+ * The envelope `use:enhance` expects back from an action: a JSON result whose
+ * `data` is a devalue-encoded string.
+ */
+const actionResult = (type: 'success' | 'failure', status: number, data: string) => ({
+	status,
+	contentType: 'application/json',
+	body: JSON.stringify({ type, status, data })
+});
+
+const saved = actionResult('success', 200, '[{"success":1},true]');
+
+const rejected = (message: string) =>
+	actionResult('failure', 400, `[{"error":1},${JSON.stringify(message)}]`);
+
+/**
+ * Intercepts the action so the tests never depend on Telegram, D1, or Turnstile
+ * being configured. Returns the bodies posted to it, in order.
+ */
+const interceptSuggest = async (page: Page, response: ReturnType<typeof actionResult>) => {
+	const posted: string[] = [];
+
+	await page.route(isSuggestAction, async (route) => {
+		posted.push(route.request().postData() ?? '');
+		await route.fulfill(response);
+	});
+
+	return posted;
+};
+
+const openDialog = async (page: Page) => {
+	await page.getByRole('button', { name: 'Suggest a restaurant' }).first().click();
+
+	const dialog = page.getByRole('dialog');
+	await expect(dialog).toBeVisible();
+
+	return dialog;
+};
+
+const fillSuggestion = async (dialog: Locator) => {
+	await dialog.getByRole('textbox', { name: 'Restaurant' }).fill('Test Kitchen');
+	await dialog.getByRole('textbox', { name: 'Location' }).fill('Sugarhouse');
+	await dialog.getByRole('textbox', { name: 'Food' }).fill('Tacos');
+	await dialog
+		.getByRole('textbox', { name: 'Why it belongs on the list' })
+		.fill('The al pastor is the best in the valley.');
+	await dialog.getByRole('textbox', { name: 'Your name' }).fill('Testy McTest');
+	await dialog.getByRole('textbox', { name: 'Your email' }).fill('testy@example.com');
+};
+
+test.describe('Suggest a restaurant', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/restaurants');
+		await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+	});
+
+	test('opens from the page and closes with Escape', async ({ page }) => {
+		await expect(page.getByRole('dialog')).toBeHidden();
+
+		const dialog = await openDialog(page);
+		// Opening puts the cursor where the visitor starts typing rather than on
+		// the close button the browser would focus by default.
+		await expect(dialog.getByRole('textbox', { name: 'Restaurant' })).toBeFocused();
+
+		await page.keyboard.press('Escape');
+		await expect(page.getByRole('dialog')).toBeHidden();
+	});
+
+	test('closes from the backdrop and from Cancel', async ({ page }) => {
+		await openDialog(page);
+		// The backdrop of a modal dialog covers the viewport, so a click in the
+		// corner lands on it rather than on the page underneath.
+		await page.mouse.click(4, 4);
+		await expect(page.getByRole('dialog')).toBeHidden();
+
+		const dialog = await openDialog(page);
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
+		await expect(page.getByRole('dialog')).toBeHidden();
+	});
+
+	test('will not submit without a restaurant and a reason', async ({ page }) => {
+		let posts = 0;
+		page.on('request', (request) => {
+			if (request.method() === 'POST') posts++;
+		});
+
+		const dialog = await openDialog(page);
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+
+		// The required fields hold the submission, so the dialog is still open and
+		// nothing reached the server.
+		await expect(dialog).toBeVisible();
+		await expect(dialog.getByRole('textbox', { name: 'Restaurant' })).toBeVisible();
+		expect(posts).toBe(0);
+
+		// A name alone is not enough either.
+		await dialog.getByRole('textbox', { name: 'Restaurant' }).fill('Test Kitchen');
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+		await expect(dialog).toBeVisible();
+		expect(posts).toBe(0);
+	});
+
+	test('sends every field to the suggest action and confirms it was saved', async ({ page }) => {
+		const posted = await interceptSuggest(page, saved);
+
+		const dialog = await openDialog(page);
+		await fillSuggestion(dialog);
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+
+		await expect(dialog.getByText('Thanks', { exact: false })).toBeVisible();
+
+		expect(posted).toHaveLength(1);
+		const fields = new URLSearchParams(posted[0]);
+		expect(Object.fromEntries(fields)).toMatchObject({
+			restaurantName: 'Test Kitchen',
+			location: 'Sugarhouse',
+			tags: 'Tacos',
+			notes: 'The al pastor is the best in the valley.',
+			submittedBy: 'Testy McTest',
+			submittedByEmail: 'testy@example.com'
+		});
+
+		await dialog.getByRole('button', { name: 'Done' }).click();
+		await expect(page.getByRole('dialog')).toBeHidden();
+	});
+
+	test("shows the server's error and keeps the filled-in suggestion", async ({ page }) => {
+		await interceptSuggest(page, rejected('Suggestions are temporarily unavailable.'));
+
+		const dialog = await openDialog(page);
+		await fillSuggestion(dialog);
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+
+		await expect(dialog.getByRole('alert')).toHaveText('Suggestions are temporarily unavailable.');
+		// Nothing typed is thrown away, so the visitor can fix and resend.
+		await expect(dialog.getByRole('textbox', { name: 'Restaurant' })).toHaveValue('Test Kitchen');
+	});
+
+	test('starts fresh when it is reopened after a suggestion', async ({ page }) => {
+		await interceptSuggest(page, saved);
+
+		const dialog = await openDialog(page);
+		await fillSuggestion(dialog);
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+		await expect(dialog.getByRole('button', { name: 'Done' })).toBeVisible();
+		await dialog.getByRole('button', { name: 'Done' }).click();
+
+		const reopened = await openDialog(page);
+		await expect(reopened.getByRole('textbox', { name: 'Restaurant' })).toHaveValue('');
+		await expect(reopened.getByRole('button', { name: 'Send suggestion' })).toBeVisible();
+	});
+
+	test('leaves the filters and the shareable URL untouched', async ({ page }) => {
+		await interceptSuggest(page, saved);
+
+		await page.getByLabel('Tag', { exact: true }).selectOption('Pizza');
+		await expect(page).toHaveURL(/tag=Pizza/);
+		const rows = await page.locator('tbody tr').count();
+
+		const dialog = await openDialog(page);
+		await fillSuggestion(dialog);
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+		await expect(dialog.getByRole('button', { name: 'Done' })).toBeVisible();
+		await dialog.getByRole('button', { name: 'Done' }).click();
+
+		await expect(page).toHaveURL(/tag=Pizza/);
+		await expect(page.locator('tbody tr')).toHaveCount(rows);
+	});
+});

--- a/e2e/restaurant-suggestions.test.ts
+++ b/e2e/restaurant-suggestions.test.ts
@@ -164,6 +164,38 @@ test.describe('Suggest a restaurant', () => {
 		await expect(reopened.getByRole('button', { name: 'Send suggestion' })).toBeVisible();
 	});
 
+	test('abandons a submission the dialog was closed on', async ({ page }) => {
+		// Held open so the dialog can be closed while the request is in flight.
+		let release = () => {};
+		const held = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		await page.route(isSuggestAction, async (route) => {
+			await held;
+			// Aborting the request makes fulfil throw, which is the expected path
+			// here rather than a failure.
+			await route.fulfill(saved).catch(() => {});
+		});
+
+		const dialog = await openDialog(page);
+		await fillSuggestion(dialog);
+		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
+
+		await page.keyboard.press('Escape');
+		await expect(page.getByRole('dialog')).toBeHidden();
+
+		// The response lands after the dialog is gone; it must not be applied to
+		// the next one.
+		release();
+
+		const reopened = await openDialog(page);
+		await expect(reopened.getByRole('textbox', { name: 'Restaurant' })).toHaveValue('');
+		// Never stuck on "Sending…", and never showing the previous thank-you.
+		await expect(reopened.getByRole('button', { name: 'Send suggestion' })).toBeEnabled();
+		await expect(reopened.getByRole('button', { name: 'Done' })).toBeHidden();
+	});
+
 	test('leaves the filters and the shareable URL untouched', async ({ page }) => {
 		await interceptSuggest(page, saved);
 

--- a/e2e/restaurant-suggestions.test.ts
+++ b/e2e/restaurant-suggestions.test.ts
@@ -33,6 +33,12 @@ const interceptSuggest = async (page: Page, response: ReturnType<typeof actionRe
 	return posted;
 };
 
+/** Whether the browser is holding a required field back as empty. */
+const valueMissing = (field: Locator) =>
+	field.evaluate(
+		(element: HTMLInputElement | HTMLTextAreaElement) => element.validity.valueMissing
+	);
+
 const openDialog = async (page: Page) => {
 	await page.getByRole('button', { name: 'Suggest a restaurant' }).first().click();
 
@@ -84,25 +90,28 @@ test.describe('Suggest a restaurant', () => {
 	});
 
 	test('will not submit without a restaurant and a reason', async ({ page }) => {
-		let posts = 0;
-		page.on('request', (request) => {
-			if (request.method() === 'POST') posts++;
-		});
+		// Scoped to the action rather than counting every POST on the page: the
+		// site's analytics beacons are POSTs too, and they fire here.
+		const posted = await interceptSuggest(page, saved);
 
 		const dialog = await openDialog(page);
+		const name = dialog.getByRole('textbox', { name: 'Restaurant' });
+		const why = dialog.getByRole('textbox', { name: 'Why it belongs on the list' });
+
 		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
 
-		// The required fields hold the submission, so the dialog is still open and
-		// nothing reached the server.
-		await expect(dialog).toBeVisible();
-		await expect(dialog.getByRole('textbox', { name: 'Restaurant' })).toBeVisible();
-		expect(posts).toBe(0);
+		// The empty restaurant field is what holds the submission back, so the
+		// dialog is still on the form and nothing reached the action.
+		await expect(name).toBeVisible();
+		expect(await valueMissing(name)).toBe(true);
+		expect(posted).toHaveLength(0);
 
-		// A name alone is not enough either.
-		await dialog.getByRole('textbox', { name: 'Restaurant' }).fill('Test Kitchen');
+		// A name alone is not enough either; now the reason is the one holding it.
+		await name.fill('Test Kitchen');
 		await dialog.getByRole('button', { name: 'Send suggestion' }).click();
-		await expect(dialog).toBeVisible();
-		expect(posts).toBe(0);
+		await expect(why).toBeVisible();
+		expect(await valueMissing(why)).toBe(true);
+		expect(posted).toHaveLength(0);
 	});
 
 	test('sends every field to the suggest action and confirms it was saved', async ({ page }) => {

--- a/migrations/0001_create_restaurant_suggestions.sql
+++ b/migrations/0001_create_restaurant_suggestions.sql
@@ -1,0 +1,20 @@
+-- Suggestions submitted from the "Suggest a restaurant" dialog on /restaurants.
+--
+-- Every submission is stored, whether or not the Telegram notification goes
+-- out, so a dropped notification never loses a suggestion. Only the restaurant
+-- name and the note are required; the rest is whatever the visitor chose to
+-- share.
+CREATE TABLE IF NOT EXISTS restaurant_suggestions (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	restaurant_name TEXT NOT NULL,
+	location TEXT,
+	tags TEXT,
+	notes TEXT NOT NULL,
+	submitted_by TEXT,
+	submitted_by_email TEXT,
+	created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- The only read this table gets is "what came in lately", newest first.
+CREATE INDEX IF NOT EXISTS restaurant_suggestions_created_at
+	ON restaurant_suggestions (created_at DESC);

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,11 +1,26 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 // and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-	// interface PrivateEnv {}
-	// interface PublicEnv {}
-	// interface Session {}
-	// interface Stuff {}
+import type { D1Database } from '@cloudflare/workers-types';
+
+declare global {
+	namespace App {
+		// interface Locals {}
+		interface Platform {
+			env?: {
+				/**
+				 * D1 binding declared in `wrangler.jsonc`. Optional because
+				 * `vite dev` and `vite preview` run outside the Workers runtime,
+				 * where there is no binding to reach.
+				 */
+				DB?: D1Database;
+			};
+		}
+		// interface PrivateEnv {}
+		// interface PublicEnv {}
+		// interface Session {}
+		// interface Stuff {}
+	}
 }
+
+export {};

--- a/src/components/SuggestRestaurantDialog.svelte
+++ b/src/components/SuggestRestaurantDialog.svelte
@@ -23,6 +23,15 @@
 	let captchaAttempt = $state(0);
 
 	/*
+	 * A submission outlives the dialog if the visitor closes it mid-flight, and
+	 * its result must not land on the next one: a late success would leave a
+	 * reopened dialog showing the previous thank-you. Closing aborts the request
+	 * and bumps the generation, so anything still in flight is ignored.
+	 */
+	let submission = 0;
+	let pending: AbortController | undefined;
+
+	/*
 	 * `showModal()` rather than the `open` attribute: it puts the dialog in the
 	 * top layer (so it clears the sticky header and the map's own stacking
 	 * context), makes the rest of the page inert, and gives us Esc-to-close and
@@ -68,6 +77,14 @@
 		open = false;
 		succeeded = false;
 		error = '';
+
+		// Abandon a submission still in flight. `submitting` is reset here rather
+		// than only in the callback, which an aborted request never reaches, so a
+		// reopened form can never come back stuck on "Sending…".
+		submission += 1;
+		pending?.abort();
+		pending = undefined;
+		submitting = false;
 	}}
 	onclick={(event) => {
 		// Only the backdrop is the dialog element itself; everything else is
@@ -114,7 +131,9 @@
 				<form
 					method="POST"
 					action="?/suggest"
-					use:enhance={() => {
+					use:enhance={({ controller }) => {
+						const attempt = (submission += 1);
+						pending = controller;
 						submitting = true;
 						error = '';
 
@@ -124,6 +143,13 @@
 						 * filters and its URL are untouched by a suggestion.
 						 */
 						return async ({ result }) => {
+							pending = undefined;
+
+							// The dialog was closed, or resubmitted, while this was in
+							// flight. Aborting usually stops the callback from running at
+							// all; this covers a response that beat the abort.
+							if (attempt !== submission) return;
+
 							submitting = false;
 
 							if (result.type === 'success') {

--- a/src/components/SuggestRestaurantDialog.svelte
+++ b/src/components/SuggestRestaurantDialog.svelte
@@ -1,0 +1,300 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { env } from '$env/dynamic/public';
+	import { Turnstile } from 'svelte-turnstile';
+	import { classNames } from '../functions/classNames';
+	import { classes } from '../styles/classes';
+
+	let { open = $bindable(false) }: { open?: boolean } = $props();
+
+	let dialog: HTMLDialogElement | undefined = $state();
+	let nameField: HTMLInputElement | undefined = $state();
+	let alertElement: HTMLParagraphElement | undefined = $state();
+
+	let submitting = $state(false);
+	let succeeded = $state(false);
+	let error = $state('');
+
+	/*
+	 * Turnstile hands out one token per challenge, and a rejected submission has
+	 * already spent it. Bumping this remounts the widget so a retry carries a
+	 * fresh token instead of a used one the server will refuse again.
+	 */
+	let captchaAttempt = $state(0);
+
+	/*
+	 * `showModal()` rather than the `open` attribute: it puts the dialog in the
+	 * top layer (so it clears the sticky header and the map's own stacking
+	 * context), makes the rest of the page inert, and gives us Esc-to-close and
+	 * focus containment for free.
+	 */
+	$effect(() => {
+		if (!dialog) return;
+
+		if (open && !dialog.open) {
+			dialog.showModal();
+			// The browser focuses the first focusable node, which is the close
+			// button. The name field is where the visitor actually starts.
+			nameField?.focus();
+		} else if (!open && dialog.open) {
+			dialog.close();
+		}
+	});
+
+	/*
+	 * The form is taller than the dialog on a short screen, and the submit button
+	 * is at the bottom of it, so an error added at the top would otherwise land
+	 * out of sight.
+	 */
+	$effect(() => {
+		if (error) alertElement?.scrollIntoView({ block: 'nearest' });
+	});
+
+	const close = () => {
+		open = false;
+	};
+</script>
+
+<!--
+	The dialog only closes through its own `close` event, so Esc, the close
+	button, and a backdrop click all land in one place.
+-->
+<dialog
+	bind:this={dialog}
+	onclose={() => {
+		// Every close route ends here, so the reset lives here too: a reopen is a
+		// fresh suggestion rather than the last one's outcome. The content is
+		// already unmounted by then, so nothing flashes.
+		open = false;
+		succeeded = false;
+		error = '';
+	}}
+	onclick={(event) => {
+		// Only the backdrop is the dialog element itself; everything else is
+		// inside the padded wrapper below.
+		if (event.target === dialog) close();
+	}}
+	aria-labelledby="suggest-restaurant-heading"
+	class={classNames(
+		'text-ink m-auto max-h-[min(85dvh,44rem)] w-[min(34rem,calc(100vw-2rem))] p-0',
+		'border-rule bg-surface shadow-lift overflow-y-auto rounded-xl border'
+	)}
+>
+	{#if open}
+		<div class="grid gap-5 p-5 sm:p-7">
+			<div class="flex items-start justify-between gap-4">
+				<div class="grid gap-2">
+					<p class={classes.eyebrow}>Suggest a restaurant</p>
+					<h2 id="suggest-restaurant-heading" class="text-h3 text-ink font-serif font-semibold">
+						Where should I eat next?
+					</h2>
+				</div>
+				<button
+					type="button"
+					onclick={close}
+					aria-label="Close"
+					class={classNames(
+						classes.label,
+						'hover:text-accent -mt-1 -mr-1 cursor-pointer p-2 text-xl leading-none'
+					)}
+				>
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</div>
+
+			{#if succeeded}
+				<div class="border-rule grid gap-4 border-t pt-5">
+					<p class="text-ink-muted font-serif text-[1.0625rem]">
+						Thanks &mdash; that&rsquo;s in my list to try. If it lives up to the write-up,
+						it&rsquo;ll show up on this page.
+					</p>
+					<button type="button" onclick={close} class={classes.button}>Done</button>
+				</div>
+			{:else}
+				<form
+					method="POST"
+					action="?/suggest"
+					use:enhance={() => {
+						submitting = true;
+						error = '';
+
+						/*
+						 * The result is handled here instead of through the default
+						 * `update()` so the outcome stays inside the dialog: the page's
+						 * filters and its URL are untouched by a suggestion.
+						 */
+						return async ({ result }) => {
+							submitting = false;
+
+							if (result.type === 'success') {
+								succeeded = true;
+								return;
+							}
+
+							captchaAttempt += 1;
+
+							error =
+								(result.type === 'failure' && typeof result.data?.error === 'string'
+									? result.data.error
+									: '') || 'Something went wrong sending that. Please try again.';
+						};
+					}}
+					class="border-rule grid gap-5 border-t pt-5"
+				>
+					<p class="text-ink-muted font-serif text-[1.0625rem]">
+						Tell me about a place you love. The name and the why are all I need; the rest helps me
+						find it.
+					</p>
+
+					{#if error}
+						<!--
+							Announced rather than only coloured, and carrying its own words, so
+							it does not depend on colour alone. Matches the contact form.
+						-->
+						<p
+							bind:this={alertElement}
+							role="alert"
+							class="border-accent-bright bg-accent-soft text-ui text-ink rounded-lg border px-4 py-3 font-sans"
+						>
+							{error}
+						</p>
+					{/if}
+
+					<div class="grid gap-1.5">
+						<label for="suggest-restaurant-name" class={classes.label}>
+							Restaurant <span aria-hidden="true" class="text-accent">*</span>
+						</label>
+						<input
+							bind:this={nameField}
+							type="text"
+							id="suggest-restaurant-name"
+							name="restaurantName"
+							maxlength="120"
+							required
+							class={classes.input}
+						/>
+					</div>
+
+					<div class="grid gap-5 sm:grid-cols-2">
+						<div class="grid gap-1.5">
+							<label for="suggest-restaurant-location" class={classes.label}>Location</label>
+							<input
+								type="text"
+								id="suggest-restaurant-location"
+								name="location"
+								maxlength="120"
+								placeholder="Neighborhood or city"
+								class={classes.input}
+							/>
+						</div>
+
+						<div class="grid gap-1.5">
+							<label for="suggest-restaurant-tags" class={classes.label}>Food</label>
+							<input
+								type="text"
+								id="suggest-restaurant-tags"
+								name="tags"
+								maxlength="120"
+								placeholder="Thai, pizza, coffee&hellip;"
+								class={classes.input}
+							/>
+						</div>
+					</div>
+
+					<div class="grid gap-1.5">
+						<label for="suggest-restaurant-notes" class={classes.label}>
+							Why it belongs on the list <span aria-hidden="true" class="text-accent">*</span>
+						</label>
+						<textarea
+							id="suggest-restaurant-notes"
+							name="notes"
+							rows="4"
+							maxlength="1500"
+							required
+							placeholder="What should I order?"
+							class={classNames(classes.input, 'resize-y')}></textarea>
+					</div>
+
+					<div class="border-rule grid gap-5 border-t pt-5 sm:grid-cols-2">
+						<div class="grid gap-1.5">
+							<label for="suggest-restaurant-submitted-by" class={classes.label}>Your name</label>
+							<input
+								type="text"
+								id="suggest-restaurant-submitted-by"
+								name="submittedBy"
+								maxlength="120"
+								class={classes.input}
+							/>
+						</div>
+
+						<div class="grid gap-1.5">
+							<label for="suggest-restaurant-email" class={classes.label}>Your email</label>
+							<input
+								type="email"
+								id="suggest-restaurant-email"
+								name="submittedByEmail"
+								maxlength="254"
+								aria-describedby="suggest-restaurant-email-hint"
+								class={classes.input}
+							/>
+							<p id="suggest-restaurant-email-hint" class={classes.label}>
+								Only if you want a reply.
+							</p>
+						</div>
+					</div>
+
+					{#if env.PUBLIC_TURNSTILE_SITE_KEY}
+						{#key captchaAttempt}
+							<div class="max-w-full min-w-0 overflow-x-auto">
+								<Turnstile siteKey={env.PUBLIC_TURNSTILE_SITE_KEY} />
+							</div>
+						{/key}
+					{/if}
+
+					<div class="border-rule flex flex-wrap items-center gap-4 border-t pt-5">
+						<button
+							type="submit"
+							disabled={submitting}
+							class={classNames(classes.button, 'disabled:cursor-progress disabled:opacity-70')}
+						>
+							{submitting ? 'Sending…' : 'Send suggestion'}
+						</button>
+						<button type="button" onclick={close} class={classes.buttonQuiet}>Cancel</button>
+					</div>
+				</form>
+			{/if}
+		</div>
+	{/if}
+</dialog>
+
+<style>
+	dialog::backdrop {
+		background-color: color-mix(in oklab, var(--ink) 45%, transparent);
+	}
+
+	/*
+		A short rise on open so the dialog reads as arriving over the page rather
+		than replacing it. The site-wide reduced-motion rule already collapses
+		animation durations, so this needs no guard of its own.
+	*/
+	dialog[open] {
+		animation: suggest-dialog-in 160ms ease-out;
+	}
+
+	@keyframes suggest-dialog-in {
+		from {
+			opacity: 0;
+			transform: translateY(0.5rem);
+		}
+	}
+
+	dialog[open]::backdrop {
+		animation: suggest-backdrop-in 160ms ease-out;
+	}
+
+	@keyframes suggest-backdrop-in {
+		from {
+			opacity: 0;
+		}
+	}
+</style>

--- a/src/routes/contact/+page.server.ts
+++ b/src/routes/contact/+page.server.ts
@@ -39,7 +39,7 @@ export const actions: Actions = {
 				'Content-Type': 'application/x-www-form-urlencoded'
 			},
 			body: new URLSearchParams({
-				secret: env.TURNSTILE_SECRET_KEY,
+				secret: env.TURNSTILE_SECRET_KEY as string,
 				response: turnstileResponse
 			})
 		});

--- a/src/routes/restaurants/+page.server.ts
+++ b/src/routes/restaurants/+page.server.ts
@@ -1,0 +1,155 @@
+import { fail } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import type { Actions } from './$types';
+
+/** Generous enough for a real suggestion, short enough to keep a Telegram message readable. */
+const maxLengths = {
+	restaurantName: 120,
+	location: 120,
+	tags: 120,
+	notes: 1500,
+	submittedBy: 120,
+	submittedByEmail: 254
+} as const;
+
+const field = (data: FormData, key: string) => data.get(key)?.toString().trim() ?? '';
+
+export const actions: Actions = {
+	suggest: async ({ request, platform }) => {
+		const turnstileSecret = env.TURNSTILE_SECRET_KEY;
+		const telegramBotToken = env.TELEGRAM_BOT_TOKEN;
+		const telegramChatId = env.TELEGRAM_CHAT_ID;
+
+		// The suggestion has nowhere to go without the D1 binding, and no spam
+		// protection without the Turnstile secret, so refuse rather than accept a
+		// submission we would silently drop. `vite dev` and `vite preview` run
+		// outside the Workers runtime, so they land here too.
+		const database = platform?.env?.DB;
+
+		if (!turnstileSecret || !telegramBotToken || !telegramChatId || !database) {
+			const missing = [
+				['TURNSTILE_SECRET_KEY', turnstileSecret],
+				['TELEGRAM_BOT_TOKEN', telegramBotToken],
+				['TELEGRAM_CHAT_ID', telegramChatId],
+				['DB binding', database]
+			]
+				.filter(([, value]) => !value)
+				.map(([key]) => key);
+
+			console.error(`Missing required restaurant suggestion config: ${missing.join(', ')}`);
+			return fail(500, {
+				error: 'Suggestions are temporarily unavailable. Please try again later.'
+			});
+		}
+
+		const data = await request.formData();
+		const restaurantName = field(data, 'restaurantName');
+		const location = field(data, 'location');
+		const tags = field(data, 'tags');
+		const notes = field(data, 'notes');
+		const submittedBy = field(data, 'submittedBy');
+		const submittedByEmail = field(data, 'submittedByEmail');
+		const turnstileResponse = field(data, 'cf-turnstile-response');
+
+		if (!restaurantName || !notes) {
+			return fail(400, {
+				error: 'Please give the restaurant a name and tell me why it belongs on the list.'
+			});
+		}
+
+		const tooLong = Object.entries({
+			restaurantName,
+			location,
+			tags,
+			notes,
+			submittedBy,
+			submittedByEmail
+		}).filter(([key, value]) => value.length > maxLengths[key as keyof typeof maxLengths]);
+
+		if (tooLong.length > 0) {
+			return fail(400, { error: 'That is longer than I can store. Please shorten it and resend.' });
+		}
+
+		// Verify Turnstile
+		if (!turnstileResponse) {
+			return fail(400, { error: 'Please complete the CAPTCHA.' });
+		}
+
+		const verifyRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded'
+			},
+			body: new URLSearchParams({
+				secret: turnstileSecret,
+				response: turnstileResponse
+			})
+		});
+
+		const verifyOutcome = await verifyRes.json();
+		if (!verifyOutcome.success) {
+			return fail(400, { error: 'CAPTCHA verification failed. Please try again.' });
+		}
+
+		// Store first, notify second: a suggestion that is saved but unannounced is
+		// recoverable, one that was announced and lost is not.
+		try {
+			await database
+				.prepare(
+					`INSERT INTO restaurant_suggestions
+						(restaurant_name, location, tags, notes, submitted_by, submitted_by_email)
+					VALUES (?, ?, ?, ?, ?, ?)`
+				)
+				.bind(
+					restaurantName,
+					location || null,
+					tags || null,
+					notes,
+					submittedBy || null,
+					submittedByEmail || null
+				)
+				.run();
+		} catch (error) {
+			console.error('Failed to save restaurant suggestion:', error);
+			return fail(500, { error: 'Failed to save your suggestion. Please try again later.' });
+		}
+
+		// Send Telegram notification
+		const text = [
+			'New restaurant suggestion!',
+			'',
+			`Restaurant: ${restaurantName}`,
+			location ? `Location: ${location}` : null,
+			tags ? `Food: ${tags}` : null,
+			submittedBy ? `From: ${submittedBy}` : null,
+			submittedByEmail ? `Email: ${submittedByEmail}` : null,
+			'',
+			'Why:',
+			notes
+		]
+			.filter((line) => line !== null)
+			.join('\n');
+
+		const telegramRes = await fetch(`https://api.telegram.org/bot${telegramBotToken}/sendMessage`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				chat_id: telegramChatId,
+				text: text
+			})
+		});
+
+		// The row is already committed, so a failed notification is mine to notice
+		// in the logs, not the visitor's to retry into a duplicate suggestion.
+		if (!telegramRes.ok) {
+			console.error(
+				'Saved restaurant suggestion but failed to send Telegram message:',
+				await telegramRes.text()
+			);
+		}
+
+		return { success: true };
+	}
+};

--- a/src/routes/restaurants/+page.server.ts
+++ b/src/routes/restaurants/+page.server.ts
@@ -130,24 +130,34 @@ export const actions: Actions = {
 			.filter((line) => line !== null)
 			.join('\n');
 
-		const telegramRes = await fetch(`https://api.telegram.org/bot${telegramBotToken}/sendMessage`, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify({
-				chat_id: telegramChatId,
-				text: text
-			})
-		});
-
 		// The row is already committed, so a failed notification is mine to notice
-		// in the logs, not the visitor's to retry into a duplicate suggestion.
-		if (!telegramRes.ok) {
-			console.error(
-				'Saved restaurant suggestion but failed to send Telegram message:',
-				await telegramRes.text()
+		// in the logs, not the visitor's to retry into a duplicate suggestion. That
+		// covers a thrown request as much as a rejected one: a DNS or timeout error
+		// escaping here would reach the visitor as a failure they would reasonably
+		// resend, which is the duplicate this ordering exists to avoid.
+		try {
+			const telegramRes = await fetch(
+				`https://api.telegram.org/bot${telegramBotToken}/sendMessage`,
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({
+						chat_id: telegramChatId,
+						text: text
+					})
+				}
 			);
+
+			if (!telegramRes.ok) {
+				console.error(
+					'Saved restaurant suggestion but failed to send Telegram message:',
+					await telegramRes.text()
+				);
+			}
+		} catch (error) {
+			console.error('Saved restaurant suggestion but the Telegram request failed:', error);
 		}
 
 		return { success: true };

--- a/src/routes/restaurants/+page.svelte
+++ b/src/routes/restaurants/+page.svelte
@@ -6,6 +6,7 @@
 	import Seo from '../../components/Seo.svelte';
 	import RestaurantMap from '../../components/RestaurantMap.svelte';
 	import RestaurantThumbnail from '../../components/RestaurantThumbnail.svelte';
+	import SuggestRestaurantDialog from '../../components/SuggestRestaurantDialog.svelte';
 	import { classNames } from '../../functions/classNames';
 	import { classes } from '../../styles/classes';
 	import {
@@ -119,6 +120,7 @@
 	let sortKey = $state<SortKey>(initial.sortKey);
 	let sortDirection = $state<SortDirection>(initial.sortDirection);
 	let activeName = $state<string | null>(null);
+	let suggesting = $state(false);
 
 	let listElement: HTMLDivElement | undefined = $state();
 
@@ -316,6 +318,11 @@
 			People ask me where to eat in Salt Lake often enough that I started keeping a list. Sort it,
 			filter it, or find something near you on the map.
 		</p>
+		<div>
+			<button type="button" onclick={() => (suggesting = true)} class={classes.button}>
+				Suggest a restaurant
+			</button>
+		</div>
 	</header>
 
 	<div class="border-rule grid gap-8 border-t pt-10 pb-8 xl:grid-cols-5">
@@ -608,7 +615,24 @@
 						{/each}
 					</ul>
 				{/if}
+
+				<!--
+					A second way in, for whoever reached the bottom of the list and
+					noticed their favorite is not on it.
+				-->
+				<div
+					class="border-rule mt-8 flex flex-wrap items-center justify-between gap-4 border-t pt-6"
+				>
+					<p class="text-ink-muted font-serif text-[1.0625rem]">
+						Somewhere missing that I should try?
+					</p>
+					<button type="button" onclick={() => (suggesting = true)} class={classes.buttonQuiet}>
+						Suggest a restaurant
+					</button>
+				</div>
 			</div>
 		</div>
 	</div>
 </div>
+
+<SuggestRestaurantDialog bind:open={suggesting} />

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,17 +8,23 @@
 		"binding": "ASSETS"
 	},
 
-	// Restaurant suggestions submitted from /restaurants. Create the database
-	// once with `bunx wrangler d1 create michaelbonner-dev` and paste the id it
-	// prints in below, then apply `migrations/` (see the README).
-	"d1_databases": [
-		{
-			"binding": "DB",
-			"database_name": "michaelbonner-dev",
-			"database_id": "REPLACE_WITH_D1_DATABASE_ID",
-			"migrations_dir": "migrations"
-		}
-	],
+	// Restaurant suggestions submitted from /restaurants, stored in D1.
+	//
+	// Left commented out because a build fails outright on a `database_id` that
+	// is not a real database, and only the account owner can create one. To turn
+	// the feature on: run `bunx wrangler d1 create michaelbonner-dev`, paste the
+	// id it prints in below, uncomment this block, and apply `migrations/` (see
+	// the README). Until then the suggestion form reports itself unavailable
+	// rather than accepting submissions it cannot store.
+	//
+	// "d1_databases": [
+	// 	{
+	// 		"binding": "DB",
+	// 		"database_name": "michaelbonner-dev",
+	// 		"database_id": "",
+	// 		"migrations_dir": "migrations"
+	// 	}
+	// ],
 
 	"vars": {
 		"PUBLIC_POSTHOG_API_KEY": "phc_CR48D5k9rHyRASc1LcsP2vkacYA7WnCTRmV7lsuDULf",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,18 @@
 		"binding": "ASSETS"
 	},
 
+	// Restaurant suggestions submitted from /restaurants. Create the database
+	// once with `bunx wrangler d1 create michaelbonner-dev` and paste the id it
+	// prints in below, then apply `migrations/` (see the README).
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "michaelbonner-dev",
+			"database_id": "REPLACE_WITH_D1_DATABASE_ID",
+			"migrations_dir": "migrations"
+		}
+	],
+
 	"vars": {
 		"PUBLIC_POSTHOG_API_KEY": "phc_CR48D5k9rHyRASc1LcsP2vkacYA7WnCTRmV7lsuDULf",
 		"PUBLIC_POSTHOG_ENABLED": "true",


### PR DESCRIPTION
Visitors can now propose a restaurant from `/restaurants`. The suggestion is stored in Cloudflare D1 and then announced over Telegram, reusing the contact form's Turnstile and Telegram configuration.

## What's here

**The dialog** — `src/components/SuggestRestaurantDialog.svelte`

A native `<dialog>` opened with `showModal()`, so it lands in the top layer above the sticky header and Leaflet's stacking context, and gets Esc-to-close, focus containment, and an inert page for free. Fields: restaurant and why it belongs on the list (required), plus location, food, your name, and your email (optional).

It keeps its own submit state instead of reading the page's `form` prop, so a suggestion never disturbs the filters or the shareable URL. Two entry points: a button in the page header and a quieter one below the list.

**The action** — `src/routes/restaurants/+page.server.ts`

Verifies Turnstile, writes the row, *then* notifies Telegram. Store-first is deliberate: a saved-but-unannounced suggestion is recoverable, an announced-but-lost one is not, so a failed notification is logged rather than shown to the visitor as a retry prompt. Missing config (any of the three env vars, or the `DB` binding) is refused with a visitor-facing "temporarily unavailable" message instead of accepting a submission that would be dropped.

**The database** — Cloudflare D1

There was no database in the repo before this, so this adds one. D1 was the natural pick given the site already deploys to Workers: no new dependencies, no extra service. Schema in `migrations/0001_create_restaurant_suggestions.sql`, `DB` binding typed in `src/app.d.ts`.

## ⚠️ One step before the feature works

**The `d1_databases` block in `wrangler.jsonc` ships commented out, so merging this does not switch the feature on.** Until the binding exists the dialog reports "Suggestions are temporarily unavailable" and accepts nothing — graceful, but a visitor clicking the button gets nothing.

To turn it on:

```bash
bunx wrangler d1 create michaelbonner-dev   # paste the printed id in, uncomment the block
bunx wrangler d1 migrations apply michaelbonner-dev --remote
```

Why commented out rather than a placeholder id: Cloudflare validates `database_id` when the build starts and rejects anything that is not a real database, so a placeholder took the Workers build red here (see the first commit). A syntactically valid but fake UUID would have been worse — it would fail every deploy of the site after merge, not just this branch.

The README section covers local dev and reading the table back. The binding only exists inside the Workers runtime, so `bun run dev` / `bun run preview` report suggestions as unavailable; `bunx wrangler dev` exercises the whole path.

## Testing

`e2e/restaurant-suggestions.test.ts` — 7 tests covering open/Escape/backdrop/Cancel, required-field enforcement, the exact payload posted to the action, the saved confirmation, the server-error path with typed input preserved, a fresh form on reopen, and the filters/URL surviving a submission. The action is intercepted, so the suite needs no Telegram, D1, or Turnstile credentials.

All 55 e2e tests pass (including a run at CI's parallelism); `bun run check` and `bun run lint` are clean.

**Not verified:** the Turnstile widget rendering inside the dialog. No local run has a site key set, so only the code path that omits the widget has been exercised — its layout inside the dialog is worth a look on the branch preview.

## Two small things outside the feature

- `src/routes/contact/+page.server.ts`: narrowed the Turnstile secret. This was the one pre-existing `bun run check` error, and it blocked verifying this branch typechecks.
- `CLAUDE.md` said the site deploys to Vercel via `adapter-vercel`. It's Cloudflare, which matters directly for the D1 docs sitting next to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Suggest a restaurant” dialog accessible from the restaurants page.
  * Added form validation, CAPTCHA protection, confirmation messaging, and error handling.
  * Suggestions can be stored and notifications sent when configured.

* **Documentation**
  * Documented the suggestion workflow, configuration, database setup, local development, and deployment guidance.

* **Tests**
  * Added end-to-end coverage for dialog behavior, validation, submission outcomes, and preserving filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->